### PR TITLE
Makefile: add -fPIE to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 CFLAGS = -I./include -O3 -nostdinc -nostdlib
-CFLAGS		+= -m64 -march=x86-64 -mno-sse2
+CFLAGS		+= -m64 -march=x86-64 -mno-sse2 -fPIE
 CFLAGS		+= -fno-stack-protector
 CFLAGS		+= -ffreestanding
 CC := gcc


### PR DESCRIPTION
The Ubuntu GCC build has --enable-default-pie, but this can't be assumed for all platforms. On Fedora this is not used and thus linking of svsm fails unless libcrt (and other libraries) are built with -fPIE added to their CFLAGS.

Related to https://github.com/svsm-vtpm/linux-svsm/pull/4
